### PR TITLE
Revert change specifying tlsv1 for IO::Socket::SSL connections which …

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -31,7 +31,6 @@ Module::Build->new (
         'FileHandle' => 0,
         'URI' => 0,
         'Carp' => 0,
-        'IO::Socket::SSL' => 0
     },
 
     configure_requires => {

--- a/lib/LabKey/Query.pm
+++ b/lib/LabKey/Query.pm
@@ -42,21 +42,6 @@ use FileHandle;
 use File::Spec;
 use File::HomeDir;
 use Carp;
-
-
-# Force all SSL connections to use TLSv1 or greater protocol. This is required for 
-# MacOSX and older Windows workstations.
-# 
-# Credit to @chrisrth on stackoverflow (http://stackoverflow.com/a/20305596)
-# See https://www.labkey.org/issues/home/Developer/issues/details.view?issueId=22146
-# for more information.
-# 
-use IO::Socket::SSL;
-my $context = new IO::Socket::SSL::SSL_Context(
-	SSL_version => 'tlsv1'
-);
-IO::Socket::SSL::set_default_context($context);
-
 use LWP::UserAgent;
 use HTTP::Cookies;
 use HTTP::Request::Common;


### PR DESCRIPTION
…was breaking connections for higher TLS versions

This change from 2015 configured IO::Socket::SSL to use TLSv1 for all connections. It was evidently necessary at the time in order to support connecting to HTTPS servers that didn't support SSLv2 or SSLv3.

https://github.com/LabKey/labkey-api-perl/commit/793b05b82d52e2cdf0f4d1fa88dbcea8bfb91ffd

In the present day, though, that code is limiting connections to ONLY TLSv1 for connections, meaning it breaks connectivity to HTTPS servers that only support TLSv1.2, which is the current standard. It's especially annoying since the configuration isn't limited to LabKey::Query itself - once you "use LabKey::Query;" anything that uses IO::Socket::SSL won't be able to deal with TLS greater than 1.0.

Furthermore, it seems as though specifying TLSv1 is no longer necessary to connect to hosts that don't support SSLv2 or SSLv3 (and let's hope that's all of them).

Finally, I'll quote from the "Common Usage Errors" section of the IO::Socket::SSL documentation:

> Set 'SSL_version' or 'SSL_cipher_list' to a "better" value.
> 
> IO::Socket::SSL tries to set these values to reasonable, secure values which are compatible with the rest of the world. But, there are some scripts or modules out there which tried to be smart and get more secure or compatible settings. Unfortunately, they did this years ago and never updated these values, so they are still forced to do only 'TLSv1' (instead of also using TLSv12 or TLSv11). Or they set 'HIGH' as the cipher list and thought they were secure, but did not notice that 'HIGH' includes anonymous ciphers, e.g. without identification of the peer.

> So it is recommended to leave the settings at the secure defaults which IO::Socket::SSL sets and which get updated from time to time to better fit the real world.

> Make SSL settings inaccessible by the user, together with bad builtin settings.

> Some modules use IO::Socket::SSL, but don't make the SSL settings available to the user. This is often combined with bad builtin settings or defaults (like switching verification off).

> Thus the user needs to hack around these restrictions by using set_args_filter_hack or similar.